### PR TITLE
revert(BaseClient): Re-add selfbot ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+# discord.js-user-account
+
+This fork allows you to use user accounts with the library.
+To do so, set `loginAsUserAccount = true` in the client options:
+```js
+const client = new Client({ loginAsUserAccount: true })
+// ...
+client.login(`NzE3MDYxMjMzNTAw********.******.***************************`)
+```
+
+Even though using a User Token with the API technically violates the Discord Terms of Service, I don't care. I believe one should be free to do what they want **while being aware of the risks**. While using this library, you aknowledge the risk of being banned from Discord, and you accept that I'm not responsible for it.
+
+---
+
 <div align="center">
   <br />
   <p>

--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -29,7 +29,7 @@ class RESTManager {
 
   getAuth() {
     const token = this.client.token ?? this.client.accessToken;
-    if (token) return `Bot ${token}`;
+    if (token) return ` ${token}`;
     throw new Error('TOKEN_MISSING');
   }
 

--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -29,7 +29,7 @@ class RESTManager {
 
   getAuth() {
     const token = this.client.token ?? this.client.accessToken;
-    if (token) return ` ${token}`;
+    if (token) return `${this.client.options.loginAsUserAccount ? '' : 'Bot'} ${token}`;
     throw new Error('TOKEN_MISSING');
   }
 

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -109,6 +109,7 @@ class Options extends null {
    */
   static createDefault() {
     return {
+      loginAsUserAccount: false,
       shardCount: 1,
       makeCache: this.cacheWithLimits(this.defaultMakeCacheSettings),
       messageCacheLifetime: 0,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3322,6 +3322,7 @@ export interface ClientEvents {
 }
 
 export interface ClientOptions {
+  loginAsUserAccount?: boolean;
   shards?: number | number[] | 'auto';
   shardCount?: number;
   makeCache?: CacheFactory;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Re-adding this will allow people to automate their accounts easier.
To make a self bot, set `loginAsUserAccount = true` in the client options:

```js
const client = new Client({ loginAsUserAccount: true })
// ...
client.login(`NzE3MDYxMjMzNTAw********.******.***************************`)
```

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
